### PR TITLE
Add batch norm for 2d and 4d inputs + tests

### DIFF
--- a/aiutils/tftools/layers.py
+++ b/aiutils/tftools/layers.py
@@ -81,3 +81,26 @@ def conv2d(input,
                                    strides=strides,
                                    padding=padding) + b)
     return output
+
+
+def batch_norm(input, name):
+    rank = len(input.get_shape().as_list())
+    in_dim = input.get_shape().as_list()[-1]
+    if rank == 2:
+        axes = [0]
+    elif rank == 4:
+        axes = [0, 1, 2]
+    else:
+        raise ValueError('rank must be 2 or 4.')
+
+    with tf.variable_scope(name):
+        mean, variance = tf.nn.moments(input, axes)
+        offset = tf.get_variable('offset',
+                                 shape=[in_dim],
+                                 initializer=tf.constant_initializer(0.0))
+        scale = tf.get_variable('scale',
+                                shape=[in_dim],
+                                initializer=tf.constant_initializer(1.0))
+        output = tf.nn.batch_normalization(input, mean, variance, offset,
+                                           scale, 1e-5)
+    return output

--- a/aiutils/tftools/layers.py
+++ b/aiutils/tftools/layers.py
@@ -84,6 +84,21 @@ def conv2d(input,
 
 
 def batch_norm(input, name):
+    """ Batch norm layer helper.
+    
+    Gets mean and variance, and creates offset and scale parameters with good initial values.
+    Then applies the batch_normalization op.
+    
+    Args:
+      input (tensor): Input to the layer. 
+        Should have shape `[batch, in_dim]` or `[batch, in_height, in_width, in_dim]`.
+        Must be one of the following types: `float32`, `float64`.
+      name (str): Name used by the `tf.variable_scope`.
+      
+    Returns:
+      output (tensor): Batch normalized activations.
+        Will have the same shape as input.
+    """
     rank = len(input.get_shape().as_list())
     in_dim = input.get_shape().as_list()[-1]
     if rank == 2:

--- a/aiutils/tftools/test_layers.py
+++ b/aiutils/tftools/test_layers.py
@@ -1,13 +1,14 @@
 import numpy as np
+import pytest
 import tensorflow as tf
 
 import layers
 
 
 def test_full():
-    batch = 32
-    in_dim = 3
-    out_dim = 10
+    batch = 1
+    in_dim = 2
+    out_dim = 3
 
     input_shape = [batch, in_dim]
     output_shape = [batch, out_dim]
@@ -24,17 +25,18 @@ def test_full():
 
 
 def test_conv2d():
-    batch = 32
-    height = 64
-    width = 64
-    in_dim = 3
-    out_dim = 10
+    batch = 1
+    height = 3
+    width = 3
+    filter_size = 3
+    in_dim = 4
+    out_dim = 5
 
     input_shape = [batch, height, width, in_dim]
     output_shape = [batch, height, width, out_dim]
 
     x = tf.placeholder(tf.float32, input_shape)
-    y = layers.conv2d(x, in_dim, out_dim, 'conv2d')
+    y = layers.conv2d(x, filter_size, out_dim, 'conv2d')
     sess = tf.Session()
     sess.run(tf.initialize_all_variables())
 
@@ -45,9 +47,9 @@ def test_conv2d():
 
 
 def test_batch_norm_2d():
-    batch = 32
-    in_dim = 3
-    out_dim = 10
+    batch = 1
+    in_dim = 2
+    out_dim = 3
 
     input_shape = [batch, in_dim]
 
@@ -63,11 +65,11 @@ def test_batch_norm_2d():
 
 
 def test_batch_norm_4d():
-    batch = 32
-    width = 64
-    height = 64
-    in_dim = 3
-    out_dim = 10
+    batch = 1
+    width = 2
+    height = 3
+    in_dim = 4
+    out_dim = 5
 
     input_shape = [batch, width, height, in_dim]
 
@@ -80,3 +82,16 @@ def test_batch_norm_4d():
     y_hat = sess.run(y, feed_dict={x: x_})
 
     assert y_hat.shape == x_.shape
+
+
+def test_batch_norm_3d():
+    batch = 1
+    width = 2
+    in_dim = 3
+    out_dim = 4
+
+    input_shape = [batch, width, in_dim]
+
+    x = tf.placeholder(tf.float32, input_shape)
+    with pytest.raises(ValueError):
+        y = layers.batch_norm(x, '4d')

--- a/aiutils/tftools/test_layers.py
+++ b/aiutils/tftools/test_layers.py
@@ -42,3 +42,41 @@ def test_conv2d():
     y_ = np.float32(np.zeros(output_shape))
     y_hat = sess.run(y, feed_dict={x: x_})
     assert (np.all(y_hat == y_))
+
+
+def test_batch_norm_2d():
+    batch = 32
+    in_dim = 3
+    out_dim = 10
+
+    input_shape = [batch, in_dim]
+
+    x = tf.placeholder(tf.float32, input_shape)
+    y = layers.batch_norm(x, '2d')
+    sess = tf.Session()
+    sess.run(tf.initialize_all_variables())
+
+    x_ = np.float32(np.random.randn(*input_shape))
+    y_hat = sess.run(y, feed_dict={x: x_})
+
+    assert y_hat.shape == x_.shape
+
+
+def test_batch_norm_4d():
+    batch = 32
+    width = 64
+    height = 64
+    in_dim = 3
+    out_dim = 10
+
+    input_shape = [batch, width, height, in_dim]
+
+    x = tf.placeholder(tf.float32, input_shape)
+    y = layers.batch_norm(x, '4d')
+    sess = tf.Session()
+    sess.run(tf.initialize_all_variables())
+
+    x_ = np.float32(np.random.randn(*input_shape))
+    y_hat = sess.run(y, feed_dict={x: x_})
+
+    assert y_hat.shape == x_.shape


### PR DESCRIPTION
Added a batch norm layer helper that works for both 2d and 4d input, in the style of #7.

Using it would look something like:
```
# 2d example
x = tf.placeholder(tf.float32, [batch, dim])
b = batch_norm(x, 'b')

# 4d example
x = tf.placeholder(tf.float32, [batch, width, height, dim])
b = batch_norm(x, 'b')
```

---

I also wrote a simple test that I guess does two things:
- checks that the layers don't throw any exceptions.
- checks the shape out the output.