### PR TITLE
:art: Moved tests to their own directory + Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pillow
+pytest
+tensorflow

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,8 @@
+# Code to help important module code without installing.
+# From: http://docs.python-guide.org/en/latest/writing/structure/#structure-of-code-is-key
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+from aiutils.tftools import layers

--- a/tests/test_tftools.py
+++ b/tests/test_tftools.py
@@ -2,8 +2,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-import layers
-
+from context import layers
 
 def test_full():
     batch = 1


### PR DESCRIPTION
The title says it all.

## Tests
This [website](http://docs.python-guide.org/en/latest/writing/structure/#structure-of-the-repository) suggests moving the tests into their own directory at the root of the repo. It also suggests a way of import things to make the tests work.

Assuming you have `py.test` installed, now you can run all the tests from the root of the repo using:

``` bash
> py.test
```

## Requirements
In theory, to install all our dependencies you just need to run:

``` bash
> pip install -r requirements.txt
```

